### PR TITLE
Feat/switch component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,26 +1,50 @@
 <main>
-  <form [formGroup]="statusForm" (submit)="handleSubmitForm()">
+  <fieldset>
+    <legend>Select and Switch - Reactive Form</legend>
+    <form [formGroup]="statusForm" (submit)="handleSubmitForm()">
+      <app-select
+        name="stateSelect"
+        [options]="stateOptions"
+        placeholder="Selecione um estado"
+        formControlName="state"
+      />
+      <div>
+        <strong>Valor selecionado: {{ statusForm.value.state }}</strong>
+      </div>
+      <app-switch formControlName="active" />
+      <div>
+        <strong>Valor selecionado: {{ statusForm.value.active }}</strong>
+      </div>
+      <button type="submit">Enviar</button>
+      {{ submittedReactiveFormValues | json }}
+    </form>
+  </fieldset>
+  <fieldset>
+    <legend>Select - ngModel</legend>
     <app-select
-      name="stateSelect"
-      [options]="stateOptions"
-      placeholder="Selecione um estado"
-      formControlName="state"
+      [(ngModel)]="genre"
+      name="genreSelect"
+      [options]="genreOptions"
+      placeholder="Selecione um gênero"
+      [disabled]="disabled"
+      [error]="error"
     />
-    <div>
-      <strong>Valor selecionado:</strong>
-    </div>
-    <button type="submit">Enviar</button>
-  </form>
-  <app-select
-    [(ngModel)]="genre"
-    name="genreSelect"
-    [options]="genreOptions"
-    placeholder="Selecione um gênero"
-    [disabled]="disabled"
-    [error]="error"
-  />
+    {{ genre }}
+  </fieldset>
+  <fieldset>
+    <legend>Switch - ngModel</legend>
+    <app-switch [(ngModel)]="autoPlay" [disabled]="disabled" />
+    {{ autoPlay }}
+  </fieldset>
+  <fieldset>
+    <legend>Switch - Event</legend>
+    <app-switch
+      (checkedChange)="handleRandomOrdemChange($event)"
+      [disabled]="disabled"
+    />
+    {{ randomOrder }}
+  </fieldset>
   <button (click)="toggleDisabled()" type="button">Toggle disabled</button>
   <button (click)="toggleError()" type="button">Toggle error</button>
-  {{genre}}
 </main>
 <router-outlet />

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,4 +5,7 @@ main {
   align-items: center;
 
   min-height: 100vh;
+  padding: 16px;
+
+  gap: 8px;
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 import { SelectComponent } from './components/select/select.component';
+import { SwitchComponent } from './components/switch/switch.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -11,7 +12,8 @@ describe('AppComponent', () => {
       ],
       declarations: [
         AppComponent,
-        SelectComponent
+        SelectComponent,
+        SwitchComponent
       ],
     }).compileComponents();
   });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,25 @@ export class AppComponent {
   disabled = false;
   error = false;
 
+  toggleDisabled() {
+    const newDisabledValue = !this.disabled;
+
+    this.disabled = newDisabledValue;
+
+    if (newDisabledValue) {
+      this.statusForm.get('state')?.disable();
+      this.statusForm.get('active')?.disable();
+    } else {
+      this.statusForm.get('state')?.enable();
+      this.statusForm.get('active')?.enable();
+    }
+  }
+
+  toggleError() {
+    this.error = !this.error;
+  }
+
+  /* Reactive Form Definitions */
   readonly stateOptions: Array<SelectOption> = [
     {
       label: "São Paulo",
@@ -27,7 +46,17 @@ export class AppComponent {
       value: "SC"
     }
   ]
+  statusForm = new FormGroup({
+    state: new FormControl(''),
+    active: new FormControl(false)
+  });
+  submittedReactiveFormValues: any;
 
+  handleSubmitForm() {
+    this.submittedReactiveFormValues = this.statusForm.value;
+  }
+
+  /* Select Component ngModel Definitions */
   genre?: SelectOptionValue;
   readonly genreOptions: Array<SelectOption> = [
     {
@@ -44,22 +73,13 @@ export class AppComponent {
     }
   ]
 
-  statusForm = new FormGroup({
-    state: new FormControl('action')
-  })
+  /* Switch Component ngModel Definition */
+  autoPlay = false;
 
-  handleSubmitForm() {
-    console.log(this.statusForm.value.state)
-  }
-  handleOnTouched() {
-    console.log("salve!")
-  }
+  /* Switch Component Event Definitions */
+  randomOrder = false;
 
-  toggleDisabled() {
-    this.disabled = !this.disabled;
-  }
-
-  toggleError() {
-    this.error = !this.error;
+  handleRandomOrdemChange(value: boolean) {
+    this.randomOrder = value;
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,11 +5,13 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SelectComponent } from './components/select/select.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SwitchComponent } from './components/switch/switch.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    SelectComponent
+    SelectComponent,
+    SwitchComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/switch/switch.component.html
+++ b/src/app/components/switch/switch.component.html
@@ -1,0 +1,25 @@
+<div
+  #switch
+  class="container"
+  [class.checked]="checked"
+  [class.disabled]="disabled"
+  role="switch"
+  tabindex="0"
+  (click)="handleSwitchToggle()"
+  (keydown)="handleKeyDown($event)"
+>
+  <div class="track">
+    <div class="key">
+      <svg
+        width="12"
+        height="10"
+        viewBox="0 0 12 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 5.32608L4.55114 9.5L12 2.10491L10.3864 0.5L4.55114 6.30151L1.60227 3.49433L0 5.32608Z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>

--- a/src/app/components/switch/switch.component.scss
+++ b/src/app/components/switch/switch.component.scss
@@ -1,0 +1,141 @@
+:host {
+  --color-unchecked: var(--color-neutral-light-00);
+  --border-color: var(--color-neutral-dark-70);
+  --track-unchecked: var(--color-neutral-light-20);
+
+  --color-checked: var(--color-action-default);
+  --track-checked: var(--color-brand-01-light);
+
+  --color-unchecked-hover: var(--color-brand-01-lightest);
+
+  --color-checked-hover: var(--color-action-hover);
+
+  --outline-color-focused: var(--color-action-focus);
+
+  --color-unchecked-disabled: var(--color-neutral-light-20);
+  --color-checked-disabled: var(--color-action-disabled);
+}
+
+.container {
+  height: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  width: fit-content;
+
+  position: relative;
+
+  .track {
+    background-color: var(--track-unchecked);
+
+    height: 1rem;
+    width: 3rem;
+
+    border-radius: 400px;
+
+    transition: background-color 0.3s;
+  }
+  .key {
+    background-color: var(--color-unchecked);
+    border-color: var(--border-color);
+
+    border-width: var(--border-width-md);
+    border-radius: 100%;
+    border-style: solid;
+    height: 1.5rem;
+    width: 1.5rem;
+
+    position: absolute;
+    top: 0;
+
+    transition: all 0.3s;
+  }
+  svg {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    fill: transparent;
+
+    transition: fill 0.3s;
+  }
+
+  // Unchecked hover
+  :hover {
+    cursor: pointer;
+
+    .key {
+      background-color: var(--color-unchecked-hover);
+
+      border-color: var(--color-checked-hover);
+    }
+  }
+
+  &:focus-visible {
+    outline-color: var(--outline-color-focused);
+
+    outline-width: var(--border-width-lg);
+    outline-style: solid;
+    outline-offset: 2px;
+  }
+
+  // Disabled unchecked
+  &.disabled,
+  &.disabled:hover {
+    * {
+      cursor: not-allowed;
+    }
+
+    .key {
+      background-color: var(--color-unchecked-disabled);
+
+      border-color: var(--color-checked-disabled);
+    }
+  }
+}
+.container.checked {
+  .key {
+    background-color: var(--color-checked);
+
+    border-color: transparent;
+
+    transform: translateX(1.5rem);
+  }
+  .track {
+    background-color: var(--track-checked);
+  }
+  svg {
+    fill: var(--color-unchecked);
+  }
+
+  // Checked hover
+  :hover {
+    cursor: pointer;
+
+    .key {
+      background-color: var(--color-checked-hover);
+    }
+  }
+
+  // Disabled checked
+  &.disabled,
+  &.disabled:hover {
+    * {
+      cursor: not-allowed !important;
+    }
+
+    .key {
+      background-color: var(--color-checked-disabled);
+
+      svg {
+        fill: var(--color-unchecked-disabled);
+      }
+    }
+
+    .track {
+      background-color: var(--track-unchecked);
+    }
+  }
+}

--- a/src/app/components/switch/switch.component.spec.ts
+++ b/src/app/components/switch/switch.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SwitchComponent } from './switch.component';
+
+describe('SwitchComponent', () => {
+  let component: SwitchComponent;
+  let fixture: ComponentFixture<SwitchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SwitchComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SwitchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set "checked" class', () => {
+    component.checked = true;
+
+    fixture.detectChanges();
+
+    const switchElement = component.switchElement.nativeElement as HTMLDivElement;
+
+    expect(switchElement.classList.contains("checked")).toBe(true);
+  })
+
+  it('should set "disabled" class', () => {
+    component.disabled = true;
+
+    fixture.detectChanges();
+
+    const switchElement = component.switchElement.nativeElement as HTMLDivElement;
+
+    expect(switchElement.classList.contains("disabled")).toBe(true);
+  })
+
+  it('should ignore "Enter" keydown code', () => {
+    const spaceKeydownEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      code: 'Enter'
+    });
+    const handleSwitchToggleSpy = spyOn(component, 'handleSwitchToggle').and.callThrough();
+
+    component.checked = false;
+    component.handleKeyDown(spaceKeydownEvent);
+
+    fixture.detectChanges();
+
+    expect(handleSwitchToggleSpy).not.toHaveBeenCalled();
+    expect(component.checked).toBe(false);
+  })
+
+  it('should receive "Space" keydown code and set "checked" to true', () => {
+    const spaceKeydownEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      code: 'Space'
+    });
+    const handleSwitchToggleSpy = spyOn(component, 'handleSwitchToggle').and.callThrough();
+
+    component.checked = false;
+    component.handleKeyDown(spaceKeydownEvent);
+
+    fixture.detectChanges();
+
+    expect(handleSwitchToggleSpy).toHaveBeenCalled();
+    expect(component.checked).toBe(true);
+  })
+
+  it('should not toggle checked value when disabled', () => {
+    component.disabled = true;
+    component.checked = false;
+    const handleSwitchToggleSpy = spyOn(component, 'handleSwitchToggle').and.callThrough();
+
+    const switchElement = component.switchElement.nativeElement as HTMLDivElement;
+    
+    switchElement.dispatchEvent(new Event('click'));
+
+    fixture.detectChanges();
+
+    expect(handleSwitchToggleSpy).toHaveBeenCalled();
+    expect(component.checked).toBe(false);
+  })
+
+  it('should set tabindex to -1 when disabled', () => {
+    component.disabled = true;
+
+    const switchElement = component.switchElement.nativeElement as HTMLDivElement;
+    
+    expect(switchElement.getAttribute('tabindex')).toBe('-1');
+  })
+});

--- a/src/app/components/switch/switch.component.ts
+++ b/src/app/components/switch/switch.component.ts
@@ -1,0 +1,59 @@
+import { Component, ElementRef, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+@Component({
+  selector: 'app-switch',
+  standalone: false,
+  templateUrl: './switch.component.html',
+  styleUrl: './switch.component.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SwitchComponent),
+      multi: true
+    }
+  ]
+})
+export class SwitchComponent implements ControlValueAccessor {
+  @Input() checked = false;
+  @Input() disabled = false;
+
+  @Output() checkedChange = new EventEmitter<boolean>();
+
+  @ViewChild('switch', { read: ElementRef, static: true}) switchElement: any;
+
+  onChange: (value: boolean) => void = () => { };
+  onTouched = () => { };
+
+  writeValue(value: any): void {
+    this.checked = value;
+  }
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  handleSwitchToggle() {
+    if (this.disabled) return;
+
+    const newValue = !this.checked;
+
+    this.writeValue(newValue);
+    this.onChange(newValue);
+    this.checkedChange.emit(newValue);
+    this.onTouched();
+  }
+
+  handleKeyDown(event: Event) {
+    if (!(event instanceof KeyboardEvent)) return;
+
+    if (event.code === "Space") {
+      this.handleSwitchToggle();
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,12 +12,14 @@
 
   // Border Width
   --border-width-sm: 1px;
+  --border-width-md: 2px;
   --border-width-lg: 4px;
 
   // Border Radius
   --border-radius-md: 4px;
 
   /* Color */
+  --color-neutral-light-00: #FFF;
   --color-neutral-light-30: #B4B4C0;
   --color-neutral-dark-70: #515162;
   --color-neutral-light-05: #F9F9FA;
@@ -25,6 +27,7 @@
 
   --color-brand-01-dark: #1F1F7A;
   --color-brand-01-lightest: #EBEBF5;
+  --color-brand-01-light: #9898CD;
   --color-action-default: #4545A1;
   --color-action-focus: #030330;
   --color-action-disabled: #B4B4C0;
@@ -40,4 +43,11 @@
   border: 0px;
 
   box-sizing: border-box;
+}
+fieldset {
+  width: 100%;
+  max-width: 760px;
+  padding: 16px;
+  border: var(--border-width-md) solid var(--color-neutral-dark-70);
+  border-radius: var(--border-radius-md);
 }


### PR DESCRIPTION
Implementa o componente "switch":
- Aplica a estrutura do componente
- Aplica o visual do handoff para os estados: Normal Unchecked, Normal Checked, Hover Unchecked, Hove Checked, Focus Unchecked, Focus Checked, Disabled Unchecked e Disabled Checked.
- Possibilita o uso com ngModel, Reactive Forms e Emissão de Evento (@Output() checkedChange)
- Adiciona os parâmetros:
  - checked => Define se o campo está marcado ou não
  - disabled => Habilita/desabilita o campo

Resolve #2.